### PR TITLE
Added CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: Main
+
+on:
+  push:
+    branches: '**'
+    tags: '*'
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    uses: adya/pack-skse-mod/.github/workflows/pack.yml@main
+    with:
+      FOMOD_MOD_NAME: "Anim Object Swapper"
+      FOMOD_MOD_AUTHOR: "powerofthree"
+      FOMOD_MOD_NEXUS_ID: "75167"
+      FOMOD_INCLUDE_PDB: true
+      PUBLISH_ARCHIVE_TYPE: '7z'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
-set(NAME "po3_AnimObjectSwapper")
-set(VERSION 1.0.0)
+set(NAME "po3_AnimObjectSwapper" CACHE STRING "")
+set(VERSION 1.0.0 CACHE STRING "")
 set(VR_VERSION 1)
 set(AE_VERSION 1)
 


### PR DESCRIPTION
Pre-configured automated build process for all supported Skyrim variants (SE/AE/VR).
Results in a FOMOD installer with all built variants.
When you push a tag it will trigger publishing as well (for now only publishes to `GitHub Releases`, later will be an option to also publish on nexus)

CACHE STRING is needed in order to retrieve this name and version outside of CMake.